### PR TITLE
Only recompile wlroots_sys when certain files have changed

### DIFF
--- a/wlroots-sys/build.rs
+++ b/wlroots-sys/build.rs
@@ -9,6 +9,11 @@ use std::process::Command;
 use std::{env, fs, io};
 
 fn main() {
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=src/wlroots.h");
+    println!("cargo:rerun-if-changed=wlroots");
+
     meson();
     let protocol_header_path =
         generate_protocol_headers().expect("Could not generate header files for wayland protocols");


### PR DESCRIPTION
Add the following lines to the beginning of the build.rs build script:

```
println!("cargo:rerun-if-changed=src/lib.rs");
println!("cargo:rerun-if-changed=src/wlroots.h");
println!("cargo:rerun-if-changed=wlroots");
```